### PR TITLE
Lowecase slugs - Finishes #106

### DIFF
--- a/lib/bibliotheca.rb
+++ b/lib/bibliotheca.rb
@@ -20,7 +20,7 @@ module Bibliotheca
     def initialize(json)
       super(json)
       @raw = schema.slice(@raw)
-      self.slug = self.slug.downcase if self.slug
+      self.slug = @raw[:slug].downcase if @raw[:slug]
     end
 
     def rebase!(organization)

--- a/lib/bibliotheca.rb
+++ b/lib/bibliotheca.rb
@@ -20,6 +20,7 @@ module Bibliotheca
     def initialize(json)
       super(json)
       @raw = schema.slice(@raw)
+      self.slug = self.slug.downcase if self.slug
     end
 
     def rebase!(organization)

--- a/spec/guide_collection_spec.rb
+++ b/spec/guide_collection_spec.rb
@@ -57,7 +57,7 @@ describe Bibliotheca::Collection::Guides do
           'foo/goo',
           Bibliotheca::Guide.new(
             name: 'foobaz',
-            slug: 'foo/goo',
+            slug: 'foo/gOo',
             language: 'haskell',
             description: 'foo',
             exercises: [{name: 'baz', description: '#goo'}]))[:id] }


### PR DESCRIPTION
Finishes #106

I did it in `SchemaDocument` because I think every document should have a lowercased slug, but I don't know if there's a better way. The `if` was because if I use the null-safe navigation operator it break some tests that don't pass any slug and then when they ask for the JSON it has a new `slug: null` field.