### PR TITLE
adding private attribute for guides

### DIFF
--- a/app/routes/guides.rb
+++ b/app/routes/guides.rb
@@ -1,9 +1,9 @@
 get '/guides' do
-  Bibliotheca::Collection::Guides.all.as_json
+  Bibliotheca::Collection::Guides.visible(current_user&.permissions).as_json
 end
 
 get '/guides/writable' do
-  Bibliotheca::Collection::Guides.allowed(current_user.permissions).as_json
+  Bibliotheca::Collection::Guides.allowed(current_user&.permissions).as_json
 end
 
 get '/guides/:id/raw' do

--- a/lib/bibliotheca/bot.rb
+++ b/lib/bibliotheca/bot.rb
@@ -11,8 +11,8 @@ class Bibliotheca::Bot
     @token = token
   end
 
-  def ensure_exists!(slug)
-    create!(slug) unless exists?(slug)
+  def ensure_exists!(slug, private)
+    create!(slug, private) unless exists?(slug)
   end
 
   def clone_into(repo, dir, &block)
@@ -66,8 +66,15 @@ class Bibliotheca::Bot
     false
   end
 
-  def create!(slug)
+  def create!(slug, private)
     octokit.create_repository(slug.repository, organization: slug.organization)
+    try_set_private!(slug) if private
+  end
+
+  def try_set_private!(slug)
+    octokit.set_private(slug.to_s)
+  rescue Octokit::NotFound
+    puts "#{slug.to_s} repository can't be set as private"
   end
 
   def writable_github_url_for(slug)

--- a/lib/bibliotheca/collection/with_slug.rb
+++ b/lib/bibliotheca/collection/with_slug.rb
@@ -1,6 +1,10 @@
 module Bibliotheca::Collection::WithSlug
   def allowed(permissions)
-    project { |it| permissions.has_permission? :writer, it.slug }
+    project { |it| permissions&.writer?(it.slug) }
+  end
+
+  def visible(permissions)
+    project { |it| !it.private || permissions&.writer?(it.slug) }
   end
 
   def find_by_slug!(slug)
@@ -12,5 +16,4 @@ module Bibliotheca::Collection::WithSlug
     upsert_by! :slug, document
   end
   alias upsert_by_slug upsert_by_slug!
-
 end

--- a/lib/bibliotheca/io/guide_export.rb
+++ b/lib/bibliotheca/io/guide_export.rb
@@ -18,7 +18,7 @@ module Bibliotheca::IO
     end
 
     def before_run_in_local_repo
-      bot.ensure_exists! repo
+      bot.ensure_exists! repo, guide.private
     end
 
     def run_in_local_repo(dir, local_repo)

--- a/lib/bibliotheca/schema/guide.rb
+++ b/lib/bibliotheca/schema/guide.rb
@@ -21,7 +21,8 @@ module Bibliotheca::Schema::Guide
       {name: :corollary},
       {name: :extra},
       {name: :AUTHORS, reverse: :authors},
-      {name: :COLLABORATORS, reverse: :collaborators}
+      {name: :COLLABORATORS, reverse: :collaborators},
+      {name: :private, default: false}
     ]
   end
 end

--- a/spec/guide_collection_spec.rb
+++ b/spec/guide_collection_spec.rb
@@ -30,6 +30,7 @@ describe Bibliotheca::Collection::Guides do
         name: 'foo',
         language: 'haskell',
         description: 'foo',
+        private: false,
         exercises: [], id: id, expectations: []}) }
 
     it { expect(inserted.raw.to_json).to json_eq ({

--- a/spec/routes/guides_spec.rb
+++ b/spec/routes/guides_spec.rb
@@ -38,6 +38,8 @@ describe 'routes' do
       build(:guide, name: 'foo2', language: 'haskell', slug: 'baz/bar2', exercises: []))
     Bibliotheca::Collection::Guides.insert!(
       build(:guide, name: 'foo3', language: 'haskell', slug: 'baz/foo', exercises: []))
+    Bibliotheca::Collection::Guides.insert!(
+      build(:guide, name: 'foo4', language: 'haskell', slug: 'bar/foo4', exercises: [], private: true))
   end
 
   def app
@@ -55,10 +57,22 @@ describe 'routes' do
   end
 
   describe('get /guides') do
-    before { get '/guides' }
+    context 'When user has permission to access private guides' do
+      before do
+        header 'Authorization', build_auth_header(writer: 'bar/*')
+        get '/guides'
+      end
 
-    it { expect(last_response).to be_ok }
-    it { expect(JSON.parse(last_response.body)['guides'].count).to eq 3 }
+      it { expect(last_response).to be_ok }
+      it { expect(JSON.parse(last_response.body)['guides'].count).to eq 4 }
+    end
+
+    context 'When user has not permission to access private guides' do
+      before { get '/guides' }
+
+      it { expect(last_response).to be_ok }
+      it { expect(JSON.parse(last_response.body)['guides'].count).to eq 3 }
+    end
   end
 
 
@@ -75,6 +89,7 @@ describe 'routes' do
                                                     slug: 'foo/bar',
                                                     description: 'foo',
                                                     exercises: [exercise],
+                                                    private: false,
                                                     id: guide_id,
                                                     expectations: []}) }
       end


### PR DESCRIPTION
Also, after deploying this version we should run this query:

```
db.guides.updateMany(
    {
        "$or": [
            { "private": { "$exists": false } }, 
            { "private": null }
        ]
    }, 
    { "$set": { "private": false } }
)
```