### PR TITLE
Fixing typo

### DIFF
--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -8,7 +8,7 @@ common: &common
 
 development:
   <<: *common
-  database: mmumuki_bibliotheca_development
+  database: mumuki_bibliotheca_development
   pool: 5
   timeout: 5000
 


### PR DESCRIPTION
Also, I don't understand why we are using two databases now :thinking: both postgres and mongo have a similar schema.

Right now running bibliotheca & bibliotheca-api for development isn't working...

- The `languages:import` and `content:import` don't exist
- While `devinit` is adding test users to mongo, the `users` table from postgres remains empty and the UI throws 500 errors
